### PR TITLE
docs: add role-based guides and plugin tooling docs

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -38,17 +38,18 @@ Operational reference for running `bluegrassdigital/wordpress-azure-sync` on Azu
 - .htaccess: WordPress normally writes this. If needed, copy our template to `/home/site/wwwroot/.htaccess` (persisted storage) from `file-templates/htaccess-template`.
 
 #### WordPress Azure Monitor plugin
-- Included in the image at `/opt/wordpress-azure-monitor`.
-- To use it, ensure the plugin directory exists under `/home/site/wwwroot/wp-content/plugins/wordpress-azure-monitor` (persisted storage). Example one-time setup:
-```
-mkdir -p /home/site/wwwroot/wp-content/plugins
-cp -r /opt/wordpress-azure-monitor /home/site/wwwroot/wp-content/plugins/wordpress-azure-monitor
-```
-- Auto-activation: set `WAZM_AUTO_ACTIVATE=1` in App Settings. On startup, once WordPress core is installed, the container will attempt to activate the plugin via WP‑CLI.
+- Bundled at `/opt/wordpress-azure-monitor` and mirrored to `/home/site/wwwroot/wp-content/plugins/wordpress-azure-monitor` on container start.
+- Auto-activation: set `WAZM_AUTO_ACTIVATE=1` in App Settings. Once WordPress core is installed, the container attempts to activate the plugin via WP‑CLI.
 - Manual activation (alternative):
 ```
 wp plugin activate wordpress-azure-monitor
 ```
+- To reinstall or activate after removal, run: `wp-azure-tools plugin-reinstall -a`
+
+#### wp-azure-tools CLI
+- Maintenance helper available inside the container; run `wp-azure-tools` for usage.
+- Common commands: `status`, `plugin-reinstall [-a]`, `rotate-logs`, `fix-perms`, `ensure-uploads`, `run-cron`, `seed-logs`, `seed-content`, `bootstrap-core`, `bootstrap-config`.
+- See [docs/wp-azure-tools.md](docs/wp-azure-tools.md) for details.
 
 #### Azure App Service deployment guidance
 - Use immutable per-build tags in production (e.g., `bluegrassdigital/wordpress-azure-sync:8.3-build-<git-sha>`), or pin by digest. Avoid `:latest`, `:stable`, and `:<full-php-version>` if you require strict immutability.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ Optimized WordPress container for Azure App Service (Linux) with App Service Sto
 - For file deploys to `/home`, restart the app/slot to pick up changes. Avoid manual rsync while Unison is running.
 
 ## Documentation
-- Operations Guide: see `OPERATIONS.md` (deployment, tags, first-time install, plugin, troubleshooting)
-- Development Guide: see `DEV.md` (local dev, example compose). For the dev variant, build the image locally when contributing:
+- Full docs by role: see [`docs/`](docs/README.md)
+- Operators: see [`OPERATIONS.md`](OPERATIONS.md) for deployment, tags, first-time install, plugin, and troubleshooting, and [`docs/wp-azure-tools.md`](docs/wp-azure-tools.md) for maintenance commands
+- Developers: see [`DEV.md`](DEV.md) for local dev and example compose. Build the dev variant locally when contributing:
   - `docker build --target dev --build-arg PHP_VERSION=8.4 -t local/wordpress-azure:8.4-dev .`
   - Then point your compose file to `local/wordpress-azure:8.4-dev`.
- - Release Process: see `RELEASING.md` (tags, changelogs, weekly vs feature releases)
+- WordPress administrators: see [`docs/wordpress-azure-monitor.md`](docs/wordpress-azure-monitor.md) for the optional Azure Monitor plugin
+- Release process: see [`RELEASING.md`](RELEASING.md) for tags, changelogs, weekly vs feature releases
 
 ## License
 MIT

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+Guides are grouped by user role:
+
+- **Operators** – deploy and run the image on Azure. See [../OPERATIONS.md](../OPERATIONS.md) for environment variables and deployment recommendations, and [wp-azure-tools.md](wp-azure-tools.md) for maintenance commands.
+- **Developers** – contribute or build locally. See [../DEV.md](../DEV.md) for the local development workflow and example compose.
+- **WordPress administrators** – monitor sync status and view logs via the optional plugin. See [wordpress-azure-monitor.md](wordpress-azure-monitor.md).
+
+For release workflow and versioning, see [../RELEASING.md](../RELEASING.md).

--- a/docs/wordpress-azure-monitor.md
+++ b/docs/wordpress-azure-monitor.md
@@ -1,0 +1,18 @@
+# WordPress Azure Monitor plugin
+
+The image ships with an optional plugin that surfaces sync status and logs inside wp-admin.
+
+## Features
+- Admin bar badge showing the current `/home` ↔ `/homelive` sync status.
+- "Azure Monitor" menu with a logs page for viewing files under `/home/LogFiles/sync`.
+- Buttons to refresh or download logs, plus capability and nonce checks for security.
+
+## Installation
+1. Ensure persistent storage is enabled for the site.
+2. On container start, the plugin is mirrored from `/opt/wordpress-azure-monitor` to `/home/site/wwwroot/wp-content/plugins/wordpress-azure-monitor`. No manual copy is required.
+3. Activate the plugin:
+   - Set `WAZM_AUTO_ACTIVATE=1` in App Settings for automatic activation at startup, **or**
+   - Activate manually with WP‑CLI: `wp plugin activate wordpress-azure-monitor`, **or**
+   - Reinstall and activate in one step: `wp-azure-tools plugin-reinstall -a`.
+
+Once active, administrators see a status badge in the admin bar and can browse logs via **Azure Monitor** in the dashboard.

--- a/docs/wp-azure-tools.md
+++ b/docs/wp-azure-tools.md
@@ -1,0 +1,27 @@
+# wp-azure-tools CLI
+
+`wp-azure-tools` is a maintenance helper available inside the container for common operational tasks.
+
+## Usage
+```
+wp-azure-tools <command> [options]
+```
+
+## Commands
+- `status` – show environment and path information.
+- `plugin-reinstall [-a]` – reinstall the bundled Azure Monitor plugin; use `-a` to activate.
+- `rotate-logs` – force logrotate for Apache logs.
+- `fix-perms [path]` – run the permission fix script (defaults to live docroot).
+- `ensure-uploads` – ensure the live uploads symlink points to persisted uploads.
+- `run-cron [home|homelive]` – run WordPress cron events due now.
+- `seed-logs` – rotate then seed logs from `/home` to `/homelive`.
+- `seed-content` – seed code and wp-content (excluding uploads) between trees.
+- `bootstrap-core [-f]` – download or refresh WordPress core (use `-f` to force).
+- `bootstrap-config [-f]` – create or refresh `wp-config.php` (use `-f` to overwrite).
+
+## Examples
+```
+wp-azure-tools status
+wp-azure-tools plugin-reinstall -a
+wp-azure-tools run-cron homelive
+```


### PR DESCRIPTION
## Summary
- document automatic install and activation options for bundled Azure Monitor plugin
- add wp-azure-tools CLI guide and link from operator docs and README for easier discovery

## Testing
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*
- `bash scripts/smoke-test.sh bluegrassdigital/wordpress-azure-sync:8.4-latest` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a8adc38a688333b3616050a86ad83e