### PR TITLE
chore: add editorconfig and document usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+insert_final_newline = true
+
+[*.{yml,yaml,json,md}]
+indent_size = 2
+
+[*.{php,sh}]
+indent_size = 4

--- a/DEV.md
+++ b/DEV.md
@@ -2,6 +2,10 @@
 
 Local development workflow for the dev image variant (composer, xdebug, tools).
 
+#### Editor configuration
+This repository includes an `.editorconfig` file so that compatible editors automatically
+apply the project's formatting conventions. Ensure your editor supports EditorConfig.
+
 #### Quick start (using Hub image)
 ```bash
 cd example
@@ -36,6 +40,4 @@ docker compose exec --user www-data -w /home/site/wwwroot wordpress wp plugin li
 #### Troubleshooting
 - 403 after first boot: ensure WordPress files exist in `/homelive/site/wwwroot`; rerun sync by restarting container.
 - DB connect errors: verify `WORDPRESS_CONFIG_EXTRA` overrides and the `db` service is healthy.
-- No admin bar badge: ensure plugin is active and check `/home/LogFiles/sync` logs.
-
-
+ - No admin bar badge: ensure plugin is active and check `/home/LogFiles/sync` logs.


### PR DESCRIPTION
## Summary
- add root-level .editorconfig for consistent indentation and newline behavior
- mention the EditorConfig in DEV.md so editors use the formatting rules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cea716b0833392d38b974a326a2b