### PR TITLE
chore: add pre-commit checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,29 @@ on:
     branches: [ master ]
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit on changed files
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_ref="origin/${{ github.base_ref }}"
+          else
+            base_ref="HEAD^"
+          fi
+          git fetch origin ${{ github.base_ref }} --depth=1 || true
+          files=$(git diff --name-only --diff-filter=AMR "$base_ref")
+          if [ -n "$files" ]; then
+            pre-commit run --files $files
+          fi
   build-and-test:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-shellcheck
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+        files: ^(scripts/.*|docker-entrypoint.sh)$
+
+  - repo: https://github.com/pre-commit/mirrors-phpcs
+    rev: v3.7.2
+    hooks:
+      - id: phpcs
+        args: [--standard=PSR12]
+        files: ^wordpress-plugin/wordpress-azure-monitor/
+
+  - repo: https://github.com/pre-commit/mirrors-phpstan
+    rev: 1.10.57
+    hooks:
+      - id: phpstan
+        files: ^wordpress-plugin/wordpress-azure-monitor/

--- a/DEV.md
+++ b/DEV.md
@@ -39,3 +39,6 @@ docker compose exec --user www-data -w /home/site/wwwroot wordpress wp plugin li
 - No admin bar badge: ensure plugin is active and check `/home/LogFiles/sync` logs.
 
 
+#### Pre-commit hooks
+- Install pre-commit (https://pre-commit.com/)
+- Run `pre-commit install` to set up git hooks


### PR DESCRIPTION
## Summary
- configure pre-commit with shellcheck, phpcs, and phpstan
- document pre-commit installation
- run pre-commit in CI on changed files

## Testing
- `pre-commit run --files .pre-commit-config.yaml DEV.md .github/workflows/ci.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ce84bfbc8333b3cb78b5bfc58e6e