### PR TITLE
Add WordPress plugin PHPUnit tests and CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+
+      - name: Install PHP dependencies
+        working-directory: wordpress-plugin/wordpress-azure-monitor
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        working-directory: wordpress-plugin/wordpress-azure-monitor
+        run: vendor/bin/phpunit
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 example/src
+wordpress-plugin/wordpress-azure-monitor/vendor/

--- a/wordpress-plugin/wordpress-azure-monitor/composer.json
+++ b/wordpress-plugin/wordpress-azure-monitor/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "wordpress-azure-monitor/plugin",
+    "type": "project",
+    "require-dev": {
+        "phpunit/phpunit": "^9.6",
+        "wp-phpunit/wp-phpunit": "^6.0"
+    }
+}

--- a/wordpress-plugin/wordpress-azure-monitor/phpunit.xml.dist
+++ b/wordpress-plugin/wordpress-azure-monitor/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Plugin Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/wordpress-plugin/wordpress-azure-monitor/tests/bootstrap.php
+++ b/wordpress-plugin/wordpress-azure-monitor/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+// Load WordPress test environment.
+$_tests_dir = getenv('WP_PHPUNIT__DIR');
+if (!$_tests_dir) {
+    $_tests_dir = dirname(__DIR__) . '/vendor/wp-phpunit/wp-phpunit';
+}
+
+require $_tests_dir . '/includes/functions.php';
+
+// Manually load the plugin.
+tests_add_filter('muplugins_loaded', function () {
+    require dirname(__DIR__) . '/wp-azure-monitor.php';
+});
+
+require $_tests_dir . '/includes/bootstrap.php';

--- a/wordpress-plugin/wordpress-azure-monitor/tests/run-download.php
+++ b/wordpress-plugin/wordpress-azure-monitor/tests/run-download.php
@@ -1,0 +1,17 @@
+<?php
+require __DIR__ . '/bootstrap.php';
+
+$log_key = $argv[1];
+
+// Create admin user and authenticate.
+$user_id = wp_create_user('admin', 'password', 'admin@example.com');
+$user = new WP_User($user_id);
+$user->set_role('administrator');
+wp_set_current_user($user_id);
+
+// Prepare request variables.
+$_GET['log'] = $log_key;
+$_GET['action'] = 'wazm_download_log';
+$_REQUEST['_wpnonce'] = wp_create_nonce('wazm_log');
+
+do_action('wp_ajax_wazm_download_log');

--- a/wordpress-plugin/wordpress-azure-monitor/tests/test-logs.php
+++ b/wordpress-plugin/wordpress-azure-monitor/tests/test-logs.php
@@ -1,0 +1,55 @@
+<?php
+
+class LogsTest extends WP_UnitTestCase {
+    private string $logDir = '/home/LogFiles/sync/apache2';
+
+    public function setUp(): void {
+        parent::setUp();
+        wp_mkdir_p($this->logDir);
+    }
+
+    public function tearDown(): void {
+        if (is_dir('/home/LogFiles')) {
+            // Cleanup created log directories and files.
+            $this->rmdir_recursive('/home/LogFiles');
+        }
+        WAZM_Logs::clear_cache();
+        parent::tearDown();
+    }
+
+    private function rmdir_recursive($dir) {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->rmdir_recursive($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    public function test_whitelist_includes_existing_log() {
+        $path = $this->logDir . '/error.log';
+        file_put_contents($path, 'sample');
+        $logs = WAZM_Logs::get_whitelisted_logs();
+        $this->assertArrayHasKey('apache-error', $logs);
+        $this->assertSame($path, $logs['apache-error']['path']);
+    }
+
+    public function test_download_endpoint_outputs_log() {
+        $path = $this->logDir . '/error.log';
+        file_put_contents($path, 'downloaded');
+
+        $script = escapeshellarg(__DIR__ . '/run-download.php');
+        $output = shell_exec(PHP_BINARY . " $script apache-error");
+        $this->assertSame('downloaded', trim($output));
+    }
+}

--- a/wordpress-plugin/wordpress-azure-monitor/tests/test-status.php
+++ b/wordpress-plugin/wordpress-azure-monitor/tests/test-status.php
@@ -1,0 +1,37 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class StatusTest extends WP_UnitTestCase {
+    private string $file = '/home/syncstatus';
+
+    public function tearDown(): void {
+        if (file_exists($this->file)) {
+            unlink($this->file);
+        }
+        WAZM_Status::clear_cache();
+        parent::tearDown();
+    }
+
+    public function test_completed_status_from_file() {
+        file_put_contents($this->file, "sync completed\n");
+        WAZM_Status::clear_cache();
+        $status = WAZM_Status::get_sync_status();
+        $this->assertSame('Completed', $status['label']);
+        $this->assertSame('green', $status['color']);
+    }
+
+    public function test_cache_is_used_until_cleared() {
+        file_put_contents($this->file, "sync completed\n");
+        WAZM_Status::clear_cache();
+        $first = WAZM_Status::get_sync_status();
+        $this->assertSame('Completed', $first['label']);
+
+        file_put_contents($this->file, "sync disabled\n");
+        $cached = WAZM_Status::get_sync_status();
+        $this->assertSame('Completed', $cached['label']);
+
+        WAZM_Status::clear_cache();
+        $updated = WAZM_Status::get_sync_status();
+        $this->assertSame('Disabled', $updated['label']);
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit and wp-phpunit dev dependencies for wordpress-azure-monitor
- scaffold WordPress test bootstrap with coverage for sync status, log whitelist, and download endpoint
- update CI to install PHP deps and run plugin test suite

## Testing
- `composer install --no-interaction --prefer-dist` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ce8ed6b88333a0fa4cdbf4e790d3