### PR TITLE
Use date-based Docker tags for weekly rebuilds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,8 +34,8 @@ jobs:
           git fetch --tags
           git checkout $(git describe --tags --abbrev=0)
 
-      - name: Set build date
-        run: echo "BUILD_DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
+      - name: Set build timestamp
+        run: echo "BUILD_DATE=$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,14 +4,14 @@ This document defines how we ship images, manage tags, and write changelogs.
 
 #### Image tags (summary)
 - Moving tags (mutable): `:8.3-latest`, `:8.4-latest`, `:8.3-dev-latest`, `:8.4-dev-latest`, `:8.x-stable`
-- Immutable (per build): `:8.3-stable-<YYYYMMDD>`, `:8.4-stable-<YYYYMMDD>`, `:8.3-dev-stable-<YYYYMMDD>`, `:8.4-dev-stable-<YYYYMMDD>`, and full PHP engine tags like `:8.3.11` (prod) and `:8.3.11-dev` (dev)
-  - CI sets `BUILD_DATE=$(date +%Y%m%d)` to generate the `<YYYYMMDD>` suffix
+- Immutable (per build): `:8.3-stable-<YYYYMMDDHHMMSS>`, `:8.4-stable-<YYYYMMDDHHMMSS>`, `:8.3-dev-stable-<YYYYMMDDHHMMSS>`, `:8.4-dev-stable-<YYYYMMDDHHMMSS>`, and full PHP engine tags like `:8.3.11` (prod) and `:8.3.11-dev` (dev)
+  - CI sets `BUILD_DATE=$(date +%Y%m%d%H%M%S)` to generate the `<YYYYMMDDHHMMSS>` suffix
 
 Production consumers should use immutable per-build tags (or digests). Moving tags are for convenience/testing.
 
 #### Cadence
 - Weekly maintenance (automated): A scheduled CI job builds fresh images to pull in upstream security/OS/PHP updates
-  - Expected outputs: new `:8.x-latest` and `:8.x-dev-latest` and new immutable `:8.x-stable-<YYYYMMDD>`/`-dev-stable-<YYYYMMDD>`
+  - Expected outputs: new `:8.x-latest` and `:8.x-dev-latest` and new immutable `:8.x-stable-<YYYYMMDDHHMMSS>`/`-dev-stable-<YYYYMMDDHHMMSS>`
   - Policy: keep a moving `:8.x-stable` pointing to the latest weekly build for each supported minor version
     - Result: there is always a stable tag available that reflects the most recent weekly build
 
@@ -31,7 +31,7 @@ Note: Production users should still pin to immutable tags even though `:8.x-stab
 #### Tagging procedures
 - Weekly maintenance (automated by CI):
   - CI builds both prod and dev images for each PHP minor (e.g., 8.3, 8.4)
-  - CI publishes `:8.x-latest`/`:8.x-dev-latest` and date-stamped tags `:8.x-stable-<YYYYMMDD>`/`-dev-stable-<YYYYMMDD>`
+  - CI publishes `:8.x-latest`/`:8.x-dev-latest` and date-stamped tags `:8.x-stable-<YYYYMMDDHHMMSS>`/`-dev-stable-<YYYYMMDDHHMMSS>`
   - CI updates `:8.x-stable` to point to the latest weekly build for each minor
 
 - Feature release (manual):
@@ -41,7 +41,7 @@ Note: Production users should still pin to immutable tags even though `:8.x-stab
   4) Publish a GitHub Release using the changelog section
 
 #### Rollback guidance
-- Prefer switching production to a previously validated immutable tag `:8.x-stable-<YYYYMMDD>` (or a pinned digest)
+- Prefer switching production to a previously validated immutable tag `:8.x-stable-<YYYYMMDDHHMMSS>` (or a pinned digest)
 - Avoid relying on moving tags (`:latest`, `:stable`) for rollbacks
 
 #### Notes


### PR DESCRIPTION
## Summary
- Check out latest git tag for scheduled builds and set BUILD_DATE
- Use date-stamped `stable` tags instead of commit SHAs
- Document weekly rebuild/tagging policy

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a987672a948333bd067212b86149f8