### PR TITLE
chore: streamline dev image tagging

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,9 +85,7 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME }}:${{ matrix.php_version }}-dev-latest
             ${{ (github.ref_type == 'tag' || github.event_name == 'schedule') && format('{0}:{1}-dev-stable', env.IMAGE_NAME, matrix.php_version) || '' }}
-            ${{ env.IMAGE_NAME }}:${{ matrix.php_version }}-dev-stable-${{ env.BUILD_DATE }}
-
-      - name: Resolve full PHP version from prod image
+        - name: Resolve full PHP version from prod image
         id: phpver_prod
         env:
           IMAGE: ${{ env.IMAGE_NAME }}
@@ -96,11 +94,12 @@ jobs:
           echo "full=$FULL" >> $GITHUB_OUTPUT
 
       - name: Resolve full PHP version from dev image
+        if: ${{ github.ref_type == 'tag' }}
         id: phpver_dev
         env:
           IMAGE: ${{ env.IMAGE_NAME }}
         run: |
-          FULL=$(docker run --rm $IMAGE:${{ matrix.php_version }}-dev-stable-${{ env.BUILD_DATE }} php -r 'echo PHP_VERSION;')
+          FULL=$(docker run --rm $IMAGE:${{ matrix.php_version }}-dev-stable php -r 'echo PHP_VERSION;')
           echo "full=$FULL" >> $GITHUB_OUTPUT
 
       - name: Add tag with full PHP version (prod, multi-arch)
@@ -112,12 +111,11 @@ jobs:
           fi
 
       - name: Add tag with full PHP version (dev, multi-arch)
+        if: ${{ github.ref_type == 'tag' }}
         env:
           IMAGE: ${{ env.IMAGE_NAME }}
         run: |
-          if [ "${{ github.ref_type }}" = "tag" ]; then \
-            docker buildx imagetools create --tag $IMAGE:${{ steps.phpver_dev.outputs.full }}-dev $IMAGE:${{ matrix.php_version }}-dev-stable-${{ env.BUILD_DATE }}; \
-          fi
+          docker buildx imagetools create --tag $IMAGE:${{ steps.phpver_dev.outputs.full }}-dev $IMAGE:${{ matrix.php_version }}-dev-stable
 
       - name: Trivy scan (prod - json)
         uses: aquasecurity/trivy-action@0.24.0
@@ -155,7 +153,7 @@ jobs:
       - name: Trivy scan (dev - json)
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: ${{ env.IMAGE_NAME }}:${{ matrix.php_version }}-dev-stable-${{ env.BUILD_DATE }}
+          image-ref: ${{ env.IMAGE_NAME }}:${{ matrix.php_version }}-dev-latest
           vuln-type: 'os,library'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
@@ -217,7 +215,7 @@ jobs:
         if: ${{ github.ref_type == 'tag' || github.event_name == 'schedule' }}
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: ${{ env.IMAGE_NAME }}:${{ matrix.php_version }}-dev-stable-${{ env.BUILD_DATE }}
+          image-ref: ${{ env.IMAGE_NAME }}:${{ matrix.php_version }}-dev-stable
           vuln-type: 'os,library'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -65,19 +65,15 @@ jobs:
             for V in "${VERSIONS[@]}"; do
               # Resolve full PHP version by querying the built image (best-effort)
               FULL_PROD=$(docker run --rm "$IMAGE_NAME:$V-build-$COMMIT_SHA" php -r 'echo PHP_VERSION;' 2>/dev/null || echo "unknown")
-              FULL_DEV=$(docker run --rm "$IMAGE_NAME:$V-dev-build-$COMMIT_SHA" php -r 'echo PHP_VERSION;' 2>/dev/null || echo "unknown")
+              FULL_DEV=$(docker run --rm "$IMAGE_NAME:$V-dev-stable" php -r 'echo PHP_VERSION;' 2>/dev/null || echo "unknown")
 
               printf "- PHP %s\n" "$V"
               printf "  - Prod: [\`%s:%s-latest\`](%s%s-latest), [\`%s:%s-stable\`](%s%s-stable), [\`%s:%s-build-%s\`](%s%s-build-%s), [\`%s:%s\`](%s%s)\n" \
                 "$IMAGE_NAME" "$V" "$DOCKER_HUB_BASE" "$V" \
+                "$IMAGE_NAME" "$V" "$DOCKER_HUB_BASE" "$V" \                "$IMAGE_NAME" "$FULL_PROD" "$DOCKER_HUB_BASE" "$FULL_PROD"
+              printf "  - Dev:  [\`%s:%s-dev-latest\`](%s%s-dev-latest), [\`%s:%s-dev-stable\`](%s%s-dev-stable), [\`%s:%s-dev\`](%s%s-dev)\n" \
                 "$IMAGE_NAME" "$V" "$DOCKER_HUB_BASE" "$V" \
-                "$IMAGE_NAME" "$V" "$COMMIT_SHA" "$DOCKER_HUB_BASE" "$V" "$COMMIT_SHA" \
-                "$IMAGE_NAME" "$FULL_PROD" "$DOCKER_HUB_BASE" "$FULL_PROD"
-              printf "  - Dev:  [\`%s:%s-dev-latest\`](%s%s-dev-latest), [\`%s:%s-dev-stable\`](%s%s-dev-stable), [\`%s:%s-dev-build-%s\`](%s%s-dev-build-%s), [\`%s:%s-dev\`](%s%s-dev)\n" \
-                "$IMAGE_NAME" "$V" "$DOCKER_HUB_BASE" "$V" \
-                "$IMAGE_NAME" "$V" "$DOCKER_HUB_BASE" "$V" \
-                "$IMAGE_NAME" "$V" "$COMMIT_SHA" "$DOCKER_HUB_BASE" "$V" "$COMMIT_SHA" \
-                "$IMAGE_NAME" "$FULL_DEV" "$DOCKER_HUB_BASE" "$FULL_DEV"
+                "$IMAGE_NAME" "$V" "$DOCKER_HUB_BASE" "$V" \                "$IMAGE_NAME" "$FULL_DEV" "$DOCKER_HUB_BASE" "$FULL_DEV"
               printf "\n"
             done
           } >> RELEASE_NOTES.md
@@ -99,7 +95,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         continue-on-error: true
         with:
-          image-ref: ${{ env.IMAGE_NAME }}:8.3-dev-build-${{ github.sha }}
+          image-ref: ${{ env.IMAGE_NAME }}:8.3-dev-stable
           vuln-type: 'os,library'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
@@ -123,7 +119,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         continue-on-error: true
         with:
-          image-ref: ${{ env.IMAGE_NAME }}:8.4-dev-build-${{ github.sha }}
+          image-ref: ${{ env.IMAGE_NAME }}:8.4-dev-stable
           vuln-type: 'os,library'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -3,8 +3,8 @@
 Operational reference for running `bluegrassdigital/wordpress-azure-sync` on Azure App Service or similar.
 
 #### Image variants
-- Moving tags (mutable): `:8.3-latest`, `:8.4-latest`, `:8.3-dev-latest`, `:8.4-dev-latest`, `:8.x-stable`, and `:<full-php-version>` if reused across releases.
-- Immutable (per-build) tags: `:8.3-build-<git-sha>` and `:8.3-dev-build-<git-sha>`.
+- Moving tags (mutable): `:8.3-latest`, `:8.4-latest`, `:8.3-dev-latest`, `:8.4-dev-latest`, `:8.3-dev-stable`, `:8.4-dev-stable`, `:8.x-stable`, and `:<full-php-version>` if reused across releases.
+- Immutable (per-build) tags: `:8.3-build-<git-sha>`.
 - Note: `:<full-php-version>` reflects the PHP engine version inside the image (e.g., `8.3.11`) but may be retagged by newer builds that keep the same PHP version. Treat it as mutable unless you verify the digest.
 
 #### Key environment variables

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,15 +3,16 @@
 This document defines how we ship images, manage tags, and write changelogs.
 
 #### Image tags (summary)
-- Moving tags (mutable): `:8.3-latest`, `:8.4-latest`, `:8.3-dev-latest`, `:8.4-dev-latest`, `:8.x-stable`
-- Immutable (per build): `:8.3-stable-<YYYYMMDDHHMMSS>`, `:8.4-stable-<YYYYMMDDHHMMSS>`, `:8.3-dev-stable-<YYYYMMDDHHMMSS>`, `:8.4-dev-stable-<YYYYMMDDHHMMSS>`, and full PHP engine tags like `:8.3.11` (prod) and `:8.3.11-dev` (dev)
+- Moving tags (mutable): `:8.3-latest`, `:8.4-latest`, `:8.3-dev-latest`, `:8.4-dev-latest`, `:8.3-dev-stable`, `:8.4-dev-stable`, `:8.x-stable`
+- Immutable (per build): `:8.3-stable-<YYYYMMDDHHMMSS>`, `:8.4-stable-<YYYYMMDDHHMMSS>`, and full PHP engine tags like `:8.3.11` (prod) and `:8.3.11-dev` (dev)
   - CI sets `BUILD_DATE=$(date +%Y%m%d%H%M%S)` to generate the `<YYYYMMDDHHMMSS>` suffix
+- Dev images only receive moving tags (`-dev-latest` and, when triggered by tags or the weekly schedule, `-dev-stable`); no per-build dev tags are produced.
 
 Production consumers should use immutable per-build tags (or digests). Moving tags are for convenience/testing.
 
 #### Cadence
 - Weekly maintenance (automated): A scheduled CI job builds fresh images to pull in upstream security/OS/PHP updates
-  - Expected outputs: new `:8.x-latest` and `:8.x-dev-latest` and new immutable `:8.x-stable-<YYYYMMDDHHMMSS>`/`-dev-stable-<YYYYMMDDHHMMSS>`
+  - Expected outputs: new `:8.x-latest`, `:8.x-dev-latest`, `:8.x-dev-stable`, and new immutable `:8.x-stable-<YYYYMMDDHHMMSS>`
   - Policy: keep a moving `:8.x-stable` pointing to the latest weekly build for each supported minor version
     - Result: there is always a stable tag available that reflects the most recent weekly build
 
@@ -31,8 +32,8 @@ Note: Production users should still pin to immutable tags even though `:8.x-stab
 #### Tagging procedures
 - Weekly maintenance (automated by CI):
   - CI builds both prod and dev images for each PHP minor (e.g., 8.3, 8.4)
-  - CI publishes `:8.x-latest`/`:8.x-dev-latest` and date-stamped tags `:8.x-stable-<YYYYMMDDHHMMSS>`/`-dev-stable-<YYYYMMDDHHMMSS>`
-  - CI updates `:8.x-stable` to point to the latest weekly build for each minor
+  - CI publishes `:8.x-latest`/`:8.x-dev-latest` and date-stamped tags `:8.x-stable-<YYYYMMDDHHMMSS>`
+  - CI updates `:8.x-stable` and `:8.x-dev-stable` to point to the latest weekly build for each minor
 
 - Feature release (manual):
   1) Update `CHANGELOG.md` moving `Unreleased` to a new section


### PR DESCRIPTION
## Summary
- limit dev image tagging to `-dev-latest` and optional `-dev-stable`
- drop `dev-build` references from release workflow
- document new dev tag set

## Testing
- `bash scripts/smoke-test.sh bluegrassdigital/wordpress-azure-sync:8.4-latest` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c7ed0e308333b666b372d8d1556c